### PR TITLE
Add missing include in storage.c

### DIFF
--- a/src/storage.c
+++ b/src/storage.c
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 
 #include "storage.h"
 


### PR DESCRIPTION
For for error in build on Ubuntu 10.04 (and maybe other Linuxes)

gcc  -O2  -g   -c -o storage.o storage.c
storage.c: In function ‘getsize’:
storage.c:114: error: storage size of ‘sb’ isn’t known
make: **\* [storage.o] Error 1
