### PR TITLE
Modify util.h(redefined CHAR_BIT)

### DIFF
--- a/engine/util.h
+++ b/engine/util.h
@@ -39,7 +39,9 @@ typedef uint32_t BITWISE __be32; /* big endian, 32 bits */
 typedef uint64_t BITWISE __be64; /* big endian, 64 bits */
 
 /* Bloom filter */
+#if CHAR_BIT != 8
 #define CHAR_BIT 8
+#endif
 #define SETBIT_1(bitset,i) (bitset[i / CHAR_BIT] |=  (1<<(i % CHAR_BIT)))
 #define SETBIT_0(bitset,i) (bitset[i / CHAR_BIT] &=  (~(1<<(i % CHAR_BIT))))
 #define GETBIT(bitset,i) (bitset[i / CHAR_BIT] &   (1<<(i % CHAR_BIT)))


### PR DESCRIPTION
[root@stest002 nessDB]# make
gcc -c -std=c99 -W -Wall -Werror -fPIC  -g -ggdb -DDEBUG   -c -o engine/ht.o engine/ht.c
In file included from engine/ht.c:12:
engine/util.h:42:1: error: "CHAR_BIT" redefined
In file included from /usr/include/bits/socket.h:31,
                 from /usr/include/sys/socket.h:35,
                 from /usr/include/netinet/in.h:24,
                 from /usr/include/arpa/inet.h:23,
                 from engine/util.h:17,
                 from engine/ht.c:12:
/usr/lib/gcc/x86_64-redhat-linux/4.1.2/include/limits.h:18:1: error: this is the location of the previous definition
make: **\* [engine/ht.o] 오류 1
[root@stest002 nessDB]# uname -a
Linux stest002 2.6.18-274.el5 #1 SMP Fri Jul 22 04:43:29 EDT 2011 x86_64 x86_64 x86_64 GNU/Linux

so adding macro #if~ #endif

is there another solution?
