### PR TITLE
Fix 'r' is used uninitialized when compiled

### DIFF
--- a/engine/serialize.c
+++ b/engine/serialize.c
@@ -532,6 +532,7 @@ int _deserialize_nonleaf_from_disk(int fd,
 				"read size [%" PRIu32 "], nid [%" PRIu64 "]",
 				exp_xsum, act_xsum,
 				real_size, bp->nid);
+		r = NESS_INNER_XSUM_ERR;
 		goto ERR;
 	}
 


### PR DESCRIPTION
When line:529 "if" condition is true, "r" is uninitialized and returned, causing compile error under LLVM

engine/serialize.c:529:6: error: variable 'r' is used uninitialized whenever 'if'
condition is true [-Werror,-Wsometimes-uninitialized]
if (exp_xsum != act_xsum)
