### PR TITLE
use foo(void) instead of foo() in function declarations

### DIFF
--- a/engine/cpair.h
+++ b/engine/cpair.h
@@ -30,7 +30,7 @@ struct cpair {
 	ness_rwlock_t value_lock;	/* barriers for value */
 };
 
-struct cpair *cpair_new();
+struct cpair *cpair_new(void);
 void cpair_init(struct cpair *cp, struct node *value);
 
 /*******************************
@@ -47,7 +47,7 @@ struct cpair_htable {
 	ness_mutex_aligned_t *mutexes;	/* array lock */
 };
 
-struct cpair_list *cpair_list_new();
+struct cpair_list *cpair_list_new(void);
 void cpair_list_free(struct cpair_list *list);
 void cpair_list_add(struct cpair_list *list, struct cpair *pair);
 void cpair_list_remove(struct cpair_list *list, struct cpair *pair);
@@ -56,7 +56,7 @@ void cpair_list_remove(struct cpair_list *list, struct cpair *pair);
 /*******************************
  * hashtable
  ******************************/
-struct cpair_htable *cpair_htable_new();
+struct cpair_htable *cpair_htable_new(void);
 void cpair_htable_free(struct cpair_htable *table);
 void cpair_htable_add(struct cpair_htable *table, struct cpair *pair);
 void cpair_htable_remove(struct cpair_htable *table, struct cpair *pair);

--- a/engine/mempool.h
+++ b/engine/mempool.h
@@ -33,7 +33,7 @@ struct mempool {
 	struct mempool_block *blocks;
 };
 
-struct mempool *mempool_new();
+struct mempool *mempool_new(void);
 char *mempool_alloc_aligned(struct mempool *pool, uint32_t bytes);
 void mempool_free(struct mempool *pool);
 

--- a/engine/options.h
+++ b/engine/options.h
@@ -29,7 +29,7 @@ struct options {
 	char *redo_path;
 };
 
-static inline struct options *options_new()
+static inline struct options *options_new(void)
 {
 	struct options *opts;
 

--- a/engine/xmalloc.c
+++ b/engine/xmalloc.c
@@ -113,12 +113,12 @@ void xfree(void *p)
 	}
 }
 
-void xreset()
+void xreset(void)
 {
 	_n_mallocs = 0;
 }
 
-void xcheck_all_free()
+void xcheck_all_free(void)
 {
 	if (_n_mallocs > 0)
 		printf("--oops, n_mallocs is [%" PRIu64 "]\n", _n_mallocs);

--- a/engine/xmalloc.h
+++ b/engine/xmalloc.h
@@ -24,7 +24,7 @@ void *xrealloc_aligned(void *p, size_t olds, size_t alignment, size_t s);
 void *xmemdup(void *p, size_t s);
 void *xmemmove(void *dst, void *src, size_t s);
 void xfree(void *p);
-void xcheck_all_free();
-void xreset();
+void xcheck_all_free(void);
+void xreset(void);
 
 #endif /* nessDB_XMALLOC_H_ */


### PR DESCRIPTION
hi Bohu, this is a trivial patch ^

in the C standard, the semantic of a function declaration `int foo();` is `foo()` accepts any number of parameters. we can make it more strict by declaring functions with no parameter by `int foo(void);`.

regards
