### PR TITLE
set default return value for  _deserialize_nonleaf_from_disk()

### DIFF
--- a/engine/serialize.c
+++ b/engine/serialize.c
@@ -500,7 +500,7 @@ int _deserialize_nonleaf_from_disk(int fd,
 		struct node **node,
 		int light)
 {
-	int r;
+	int r = NESS_ERR;
 	uint32_t read_size;
 	uint32_t real_size;
 	struct buffer *rbuf = NULL;


### PR DESCRIPTION
hi Bohu, 

nessDB build failed on my OS X 10.9 with the following error message: https://gist.github.com/anonymous/8999425/raw, it shows that `r` in `_deserialize_nonleaf_from_disk()` wasn't initialised on some goto branches. this pr set up a default value of `NESS_ERR` for it. 

regards
